### PR TITLE
Final fix for autosave message breaking editor textarea 

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
-base   codemirror
+base   codemirror-fixed
 author Albert Gasset (fix by CosmoCode & ajshea)
 email  albertgasset@fsfe.org
 date   2021-05-15
-name   CodeMirror plugin
+name   CodeMirror-Fixed plugin
 desc   Editor with syntax highlighting
 url    https://github.com/ajshea/dokuwiki-plugin-codemirror/releases/download/latest/dokuwiki-plugin-codemirror.tar.gz

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
-base   codemirror-fixed
+base   codemirror2
 author Albert Gasset (fix by CosmoCode & ajshea)
 email  albertgasset@fsfe.org
 date   2021-05-15
-name   CodeMirror-Fixed plugin
+name   CodeMirror2 Fixed plugin
 desc   Editor with syntax highlighting
-url    https://github.com/ajshea/dokuwiki-plugin-codemirror/releases/download/latest/dokuwiki-plugin-codemirror.tar.gz
+url    https://github.com/ajshea/dokuwiki-plugin-codemirror/releases/download/master/dokuwiki-plugin-codemirror.tar.gz

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -4,4 +4,4 @@ email  albertgasset@fsfe.org
 date   2021-05-15
 name   CodeMirror2 Fixed plugin
 desc   Editor with syntax highlighting
-url    https://github.com/ajshea/dokuwiki-plugin-codemirror/releases/download/master/dokuwiki-plugin-codemirror.tar.gz
+url    https://github.com/ajshea/dokuwiki-plugin-codemirror/releases/download/latest/dokuwiki-plugin-codemirror.tar.gz

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
-base   codemirror2
+base   codemirrorfix
 author Albert Gasset (fix by CosmoCode & ajshea)
 email  albertgasset@fsfe.org
-date   2021-05-15
-name   CodeMirror2 Fixed plugin
+date   2021-06-15
+name   CodeMirrorFix plugin
 desc   Editor with syntax highlighting
-url    https://github.com/ajshea/dokuwiki-plugin-codemirror/releases/download/latest/dokuwiki-plugin-codemirror.tar.gz
+url    https://www.dokuwiki.org/plugin:codemirror

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   codemirror
-author Albert Gasset (fix by CosmoCode)
+author Albert Gasset (fix by CosmoCode & ajshea)
 email  albertgasset@fsfe.org
-date   2020-09-05
+date   2021-05-15
 name   CodeMirror plugin
 desc   Editor with syntax highlighting
-url    https://github.com/albertgasset/dokuwiki-plugin-codemirror
+url    https://github.com/ajshea/dokuwiki-plugin-codemirror/releases/download/latest/dokuwiki-plugin-codemirror.tar.gz

--- a/styles.less
+++ b/styles.less
@@ -1,7 +1,7 @@
 form#dw__editform, #dokuwiki__content {
     @import (less) "node_modules/codemirror/lib/codemirror.css";
 }
-
+ 
 form#dw__editform {
     @import (less) "node_modules/codemirror/addon/dialog/dialog.css";
     @import (less) "node_modules/codemirror/addon/search/matchesonscrollbar.css";
@@ -123,3 +123,4 @@ div.dokuwiki div#size__ctl {
 .cm-underline {
     text-decoration: underline;
 }
+/* version bump */

--- a/styles.less
+++ b/styles.less
@@ -69,6 +69,7 @@ form#dw__editform {
         box-shadow: none;
         line-height: 1.25;
         padding-left: 7px;
+        width: 100%;
     }
 
     .CodeMirror-scrollbar-filler {

--- a/styles.less
+++ b/styles.less
@@ -61,6 +61,7 @@ form#dw__editform {
         border-radius: 2px;
         word-wrap: normal;
         text-align: left;
+        width: 100%;
     }
 
     .CodeMirror pre {


### PR DESCRIPTION
adding 100% width to pre fixes autosave and preview breaking editor textarea on other dokuwiki templates