### PR TITLE
Final fix for autosave message breaking editor textarea

### DIFF
--- a/styles.less
+++ b/styles.less
@@ -61,6 +61,7 @@ form#dw__editform {
         border-radius: 2px;
         word-wrap: normal;
         text-align: left;
+        width: 100%;
     }
 
     .CodeMirror pre {
@@ -68,6 +69,7 @@ form#dw__editform {
         box-shadow: none;
         line-height: 1.25;
         padding-left: 7px;
+        width: 100%;
     }
 
     .CodeMirror-scrollbar-filler {


### PR DESCRIPTION
Some templates need both fixes to prevent the autosave message from breaking the editor textarea